### PR TITLE
Change externalTrafficPolicy in Pihole Deployment

### DIFF
--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/PiHole-Deployment.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/PiHole-Deployment.yaml
@@ -109,6 +109,6 @@ spec:
     targetPort: 53
   selector:
     app: pihole
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: Local
   loadBalancerIP: 192.168.3.67 # this is your DNS IP, NOT THE GUI!
   type: LoadBalancer


### PR DESCRIPTION
Modified the externalTrafficPolicy to point to Local instead of Cluster. This enables the query log within Pihole to show external IP's vs the cluster IP. I have validated this change to be effective within my RKE2 Cluster. 