### PR TITLE
Remove deprecated DNS environment varibles

### DIFF
--- a/Pihole/docker-compose.yml
+++ b/Pihole/docker-compose.yml
@@ -41,8 +41,7 @@ services:
     environment:
       TZ: 'Europe/London'
       WEBPASSWORD: 'password'
-      DNS1: '172.70.9.2#5053'
-      DNS2: 'no'
+      PIHOLE_DNS_: '172.70.9.2#5053'
       DNSMASQ_LISTENING: 'all'
       VIRTUAL_HOST: pihole.yourdomain.com
     # Volumes store your data between container upgrades


### PR DESCRIPTION
As mentioned in the official PiHole Docs, the `DNS1` and `DNS2` environment variables are deprecated and replaced by the variable `PIHOLE_DNS_` ([Link to Docs](https://github.com/pi-hole/docker-pi-hole?tab=readme-ov-file))