### PR TITLE
kubectl apply $HOME/ipAddressPool.yaml

### DIFF
--- a/Kubernetes/K3S-Deploy/k3s.sh
+++ b/Kubernetes/K3S-Deploy/k3s.sh
@@ -195,7 +195,7 @@ kubectl wait --namespace metallb-system \
                 --for=condition=ready pod \
                 --selector=component=controller \
                 --timeout=120s
-kubectl apply -f ipAddressPool.yaml
+kubectl apply -f $HOME/ipAddressPool.yaml
 kubectl apply -f https://raw.githubusercontent.com/JamesTurland/JimsGarage/main/Kubernetes/K3S-Deploy/l2Advertisement.yaml
 
 kubectl get nodes


### PR DESCRIPTION
If you're *not* running your script from $HOME, then the kubectl apply ipAddressPool.yaml was failing (no path for the YAML file in the command). 