### PR TITLE
Added pihole redirect middleware

### DIFF
--- a/Kubernetes/Traefik-PiHole/Helm/Traefik/values.yaml
+++ b/Kubernetes/Traefik-PiHole/Helm/Traefik/values.yaml
@@ -1,6 +1,6 @@
 globalArguments:
   - "--global.sendanonymoususage=false"
-  - "--global.checknewversion=false"
+  - "--global.checknewversion=true"
 
 additionalArguments:
   - "--serversTransport.insecureSkipVerify=true"
@@ -48,7 +48,7 @@ service:
   annotations: {}
   labels: {}
   spec:
-    loadBalancerIP: 192.168.3.65 # this should be an IP in the Kube-VIP range
+    loadBalancerIP: 10.20.67.51 # this should be an IP in the Kube-VIP range
     externalTrafficPolicy: Local # needed for real IP to be shown for external devices
   loadBalancerSourceRanges: []
   externalIPs: []

--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
@@ -22,5 +22,6 @@ spec:
           port: 80
       middlewares:
         - name: default-headers
+        - name: pihole-redirect
   tls:
     secretName: jimsgarage-tls # change to your cert name

--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/pihole-redirect.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/pihole-redirect.yaml
@@ -1,0 +1,26 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  creationTimestamp: '2024-01-02T15:45:45Z'
+  generation: 1
+  managedFields:
+    - apiVersion: traefik.containo.us/v1alpha1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:spec:
+          .: {}
+          f:redirectRegex:
+            .: {}
+            f:regex: {}
+            f:replacement: {}
+      manager: rancher
+      operation: Update
+      time: '2024-01-02T15:45:45Z'
+  name: pihole-redirect
+  namespace: pihole
+  resourceVersion: '849681'
+  uid: 22f3be2e-1fcf-4a8c-973e-0a89ccc41bdf
+spec:
+  redirectRegex:
+    regex: ^https?://yourdomain.com/$ # update to your pihole domain. Only replace "yourdomain.com"
+    replacement: https://yourdomain.com/admin/ # update to your pihole domain. Only replace "yourdomain.com"


### PR DESCRIPTION
Added a pihole redirect middleware to fix the 403 unauthorized error when deploying pihole in kubernetes. 
This change adds new middleware called pihole-redirect to Manifest/pihole/ 

All this middleware does is point any traefik hitting pihole.yourdomain.com to pihole.yourdomain.com/admin