### PR TITLE
Added Pihole redirect middleware to Kubernetes deployment

### DIFF
--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
@@ -22,5 +22,6 @@ spec:
           port: 80
       middlewares:
         - name: default-headers
+        - name: pihole-redirect
   tls:
     secretName: jimsgarage-tls # change to your cert name

--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/pihole-redirect.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/pihole-redirect.yaml
@@ -1,0 +1,26 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  creationTimestamp: '2024-01-02T15:45:45Z'
+  generation: 1
+  managedFields:
+    - apiVersion: traefik.containo.us/v1alpha1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:spec:
+          .: {}
+          f:redirectRegex:
+            .: {}
+            f:regex: {}
+            f:replacement: {}
+      manager: rancher
+      operation: Update
+      time: '2024-01-02T15:45:45Z'
+  name: pihole-redirect
+  namespace: pihole
+  resourceVersion: '849681'
+  uid: 22f3be2e-1fcf-4a8c-973e-0a89ccc41bdf
+spec:
+  redirectRegex:
+    regex: ^https?://yourdomain.com/$ # update to your pihole domain. Only replace "yourdomain.com"
+    replacement: https://yourdomain.com/admin/ # update to your pihole domain. Only replace "yourdomain.com"


### PR DESCRIPTION
Added a new middleware to the traefik | pihole Kubernetes deployment. 
This new middleware fixes the annoying 403 error you get when accessing pihole through traefik SSL

With this change you will no longer need to add /admin manually at the end of your domain. 
This middleware is a simple regex that redirects anything hitting pihole.yourdomain.com to pihole.yourdomain.com/admin. 