### PR TITLE
Update docker-compose.yaml 

### DIFF
--- a/Immich/docker-compose.yaml
+++ b/Immich/docker-compose.yaml
@@ -9,10 +9,11 @@ services:
       - /home/ubuntu/docker/immich/upload:/usr/src/app/upload
     env_file:
       - .env
+    ports:
+      - 2283:3001
     depends_on:
       - redis
       - database
-      - typesense
     restart: always
 
   immich-microservices:
@@ -29,7 +30,6 @@ services:
     depends_on:
       - redis
       - database
-      - typesense
     restart: always
 
   immich-machine-learning:
@@ -41,25 +41,6 @@ services:
       - .env
     restart: always
 
-  immich-web:
-    container_name: immich_web
-    image: ghcr.io/immich-app/immich-web:${IMMICH_VERSION:-release}
-    env_file:
-      - .env
-    restart: always
-
-  typesense:
-    container_name: immich_typesense
-    image: typesense/typesense:0.24.1@sha256:9bcff2b829f12074426ca044b56160ca9d777a0c488303469143dd9f8259d4dd
-    environment:
-      - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
-      - TYPESENSE_DATA_DIR=/data
-      # remove this to get debug messages
-      - GLOG_minloglevel=1
-    volumes:
-      - /home/ubuntu/docker/immich/tsdata:/data
-    restart: always
-
   redis:
     container_name: immich_redis
     image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
@@ -67,7 +48,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    image: tensorchord/pgvecto-rs:pg14-v0.1.11
     env_file:
       - .env
     environment:
@@ -76,20 +57,6 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME}
     volumes:
       - /home/ubuntu/docker/immich/pgdata:/var/lib/postgresql/data
-    restart: always
-
-  immich-proxy:
-    container_name: immich_proxy
-    image: ghcr.io/immich-app/immich-proxy:${IMMICH_VERSION:-release}
-    environment:
-      # Make sure these values get passed through from the env file
-      - IMMICH_SERVER_URL
-      - IMMICH_WEB_URL
-    ports:
-      - 2283:8080
-    depends_on:
-      - immich-server
-      - immich-web
     restart: always
 
 ## there is a known issue with Traefik: see here https://github.com/immich-app/immich/discussions/437#discussioncomment-3609797


### PR DESCRIPTION
Updated for v1.91.0 (no longer uses typesense) and v1.88.0 (no longer uses immich-web or immich-proxy, port - 2283:3001 exposed on immich-server). 

I'm not sure how to deal with Traefik labels or other URL stuff you had going on in there, but these are the changed made for it to function on the localhost:2283

Documentation:
https://github.com/immich-app/immich/releases/tag/v1.91.0 https://github.com/immich-app/immich/discussions/5086