### PR TITLE
Enable ssh access on gitea

### DIFF
--- a/Gitea/docker-compose.yaml
+++ b/Gitea/docker-compose.yaml
@@ -4,9 +4,13 @@ services:
   server:
     image: gitea/gitea:1.21.4
     container_name: gitea
+    ports:
+      - "222:22"
     environment:
       - USER_UID=1000
       - USER_GID=1000
+      - SSH_PORT=222
+      - SSH_LISTEN_PORT=22
       - GITEA__database__DB_TYPE=postgres
       - GITEA__database__HOST=db:5432
       - GITEA__database__NAME=gitea


### PR DESCRIPTION
Configure gitea to be accessed by ssh. This is done by setting the variables:

* [`SSH_PORT`][0]: port displayed in clone url
* [`SSH_LISTEN_PORT`][1]: port for the built-in ssh server

Besides that, it's necessary to map container port 222 to host port 22.

With these changes, one can clone a repository using `ssh://git@<hostname>:222/<username>/<repository>.git`.

[0]: https://docs.gitea.com/administration/config-cheat-sheet?_highlight=ssh_port#server-server
[1]: https://docs.gitea.com/administration/config-cheat-sheet?_highlight=ssh_listen_port#server-server