### PR TITLE
fixed path for ipAddressPool.yaml, changed to $HOME/ipAddressPool

### DIFF
--- a/Kubernetes/K3S-Deploy/k3s.sh
+++ b/Kubernetes/K3S-Deploy/k3s.sh
@@ -195,7 +195,7 @@ kubectl wait --namespace metallb-system \
                 --for=condition=ready pod \
                 --selector=component=controller \
                 --timeout=120s
-kubectl apply -f ipAddressPool.yaml
+kubectl apply -f $HOME/ipAddressPool.yaml
 kubectl apply -f https://raw.githubusercontent.com/JamesTurland/JimsGarage/main/Kubernetes/K3S-Deploy/l2Advertisement.yaml
 
 kubectl get nodes


### PR DESCRIPTION
In the test phase the path for ipAddressPool.yaml was set directly but in above step the file was written to $HOME/ipAddressPool.yaml. So change the path for kubectl apply.

Because of this ngix-1 service was showing pending in Exnternal IP