### PR TITLE
fix:e ansible/ssh/readme.md (typo in a command)

### DIFF
--- a/Ansible/SSH/readme.md
+++ b/Ansible/SSH/readme.md
@@ -14,7 +14,7 @@ ansible all -m ping
 
 # Create SSH Key
 ```
-ssh keygen -t ed25519 -C "ansible"
+ssh-keygen -t ed25519 -C "ansible"
 ```
 
 # Copy SSH Key


### PR DESCRIPTION
Fixed typo on the Create SSH key command