### PR TITLE
Fix "Unsupported parameters for (stat) module: get_md5."

### DIFF
--- a/Ansible/Playbooks/Update/update.yml
+++ b/Ansible/Playbooks/Update/update.yml
@@ -10,7 +10,7 @@
 
     - name: Check if a reboot is needed on all servers
       register: reboot_required_file
-      stat: path=/var/run/reboot-required get_checksum=false
+      stat: path=/var/run/reboot-required get_checksum=no
 
     - name: Reboot the box if kernel updated
       reboot:

--- a/Ansible/Playbooks/Update/update.yml
+++ b/Ansible/Playbooks/Update/update.yml
@@ -10,7 +10,7 @@
 
     - name: Check if a reboot is needed on all servers
       register: reboot_required_file
-      stat: path=/var/run/reboot-required get_md5=no
+      stat: path=/var/run/reboot-required get_checksum=false
 
     - name: Reboot the box if kernel updated
       reboot:


### PR DESCRIPTION
Currently getting this error:
```
TASK [Check if a reboot is needed on all servers] ***************************************************************************************************
fatal: [192.168.0.176]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (stat) module: get_md5. Supported parameters include: checksum_algorithm, follow, get_attributes, get_checksum, get_mime, path (attr, attributes, checksum, checksum_algo, dest, mime, mime-type, mime_type, name)."}
```

The fix is to use `get_checksum=no` instead of `get_md5=no`.

It seems get_md5 was depracated from ansible quite a long time ago (see https://github.com/ansible/ansible/commit/8386201242296e842b03f3e3826fcdbdf2dadfcb). 
