### PR TITLE
Replace deprecated get_md5 witch get_checksum

### DIFF
--- a/Ansible/Playbooks/Update/update.yml
+++ b/Ansible/Playbooks/Update/update.yml
@@ -10,7 +10,7 @@
 
     - name: Check if a reboot is needed on all servers
       register: reboot_required_file
-      stat: path=/var/run/reboot-required get_md5=no
+      stat: path=/var/run/reboot-required get_checksum=false
 
     - name: Reboot the box if kernel updated
       reboot:


### PR DESCRIPTION
The get_md5 for stat is unsupported and get_md5=no doesn't work with ansible 9.3.0.

See: https://github.com/geerlingguy/ansible-role-swap/issues/32#issuecomment-1845897639