### PR TITLE
Add Kubernetes deployment for Cloudflare Tunnel

### DIFF
--- a/Cloudflare-Tunnel/kubernetes-deployment.yaml
+++ b/Cloudflare-Tunnel/kubernetes-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-tunnel
+  namespace: cloudflare-tunnel
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cloudflared-tunnel
+  template:
+    metadata:
+      labels:
+        app: cloudflared-tunnel
+    spec:
+      nodeSelector:
+        worker: "true"
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          command:
+            [
+              "cloudflared",
+              "tunnel",
+              "--no-autoupdate",
+              "run",
+              "--token",
+              "<ADD YOUR TOKEN HERE>",
+            ]


### PR DESCRIPTION
Hi,

I've migrated my existing Cloudflare Tunnel into my RKE2-Cluster and want to share the deployment-file.

Unfortunately this deployment omits the networking part of the Docker-compose file. Therefore Cloudflare has full access to your entire network, which is probably not desirable. Maybe adding a Network Policy is a good idea, but i didn't want to overcomplicate the deployment file.

Because of the security implication of this deployment, I can understand, if you don't want to merge it in. Maybe an idea for a video though ;)

Best regards
Philipp