### PR TITLE
Traefik v3 requires updating the CRDs API group version

### DIFF
--- a/Kubernetes/Create-manifest-helm/Portainer/default-headers.yaml
+++ b/Kubernetes/Create-manifest-helm/Portainer/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/Create-manifest-helm/Portainer/ingress.yaml
+++ b/Kubernetes/Create-manifest-helm/Portainer/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: portainer

--- a/Kubernetes/Create-manifest-helm/WireGuard-Easy/default-headers.yaml
+++ b/Kubernetes/Create-manifest-helm/WireGuard-Easy/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/Create-manifest-helm/WireGuard-Easy/ingress.yaml
+++ b/Kubernetes/Create-manifest-helm/WireGuard-Easy/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: wg-easy

--- a/Kubernetes/Create-manifest-helm/WireGuard-Easy/ingressRouteUDP.yaml
+++ b/Kubernetes/Create-manifest-helm/WireGuard-Easy/ingressRouteUDP.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteUDP
 metadata:
   name: wg-easy

--- a/Kubernetes/CrowdSec/Bouncer/bouncer-middleware.yaml
+++ b/Kubernetes/CrowdSec/Bouncer/bouncer-middleware.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: bouncer

--- a/Kubernetes/GitOps/Gotify/default-headers.yaml
+++ b/Kubernetes/GitOps/Gotify/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/GitOps/Gotify/ingress.yaml
+++ b/Kubernetes/GitOps/Gotify/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: gotify

--- a/Kubernetes/Traefik-External-Service/default-headers.yaml
+++ b/Kubernetes/Traefik-External-Service/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/Traefik-External-Service/ingress.yaml
+++ b/Kubernetes/Traefik-External-Service/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: proxmox

--- a/Kubernetes/Traefik-PiHole/Helm/Traefik/Dashboard/ingress.yaml
+++ b/Kubernetes/Traefik-PiHole/Helm/Traefik/Dashboard/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: traefik-dashboard

--- a/Kubernetes/Traefik-PiHole/Helm/Traefik/Dashboard/middleware.yaml
+++ b/Kubernetes/Traefik-PiHole/Helm/Traefik/Dashboard/middleware.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: traefik-dashboard-basicauth

--- a/Kubernetes/Traefik-PiHole/Helm/Traefik/default-headers.yaml
+++ b/Kubernetes/Traefik-PiHole/Helm/Traefik/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/default-headers.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/default-headers.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers

--- a/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
+++ b/Kubernetes/Traefik-PiHole/Manifest/PiHole/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: pihole

--- a/Kubernetes/Traefik-PiHole/readme.md
+++ b/Kubernetes/Traefik-PiHole/readme.md
@@ -2,3 +2,25 @@
 Make sure that you watch the video instructions carefully as you need to amend the files correctly.
 YOU CANNOT JUST RUN THIS SCRIPT!
 Incorrect use can result in you being locked out of Lets Encrypt for a period of time.
+
+# NOTE FOR TRAEFIK v3 #
+Many guides out there (including, until recently, this repo) reference an older version of the Kubernetes CRDs API group.
+This older version is [deprecated](https://doc.traefik.io/traefik/master/migration/v2-to-v3/#kubernetes-crds-api-group-traefikcontainous) 
+as of Traefik v3 (released [29 April 2024](https://github.com/traefik/traefik/releases/tag/v3.0.0)) and must be updated to the new version
+in your IngressRoute, Middleware, ServersTransport, etc. yaml manifests for Traefik.  Any resources with the deprecated version will not 
+be recognized by Traefik v3.
+
+Old, deprecated version:
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+```
+
+New, supported version:
+```yaml
+apiVersion: traefik.io/v1alpha1
+```
+This new version is also supported in later releases of Traefik v2, so you can update your Traefik-related manifests 
+to the new version and apply the updated manifests before upgrading your Traefik deployment.
+
+It may be worth reviewing other v2 to v3 migration notes provided by Traefik: 
+[Traefik v2 to v3 Migration](https://doc.traefik.io/traefik/master/migration/v2-to-v3/)

--- a/Unifi-Controller/kubernetes/ingress.yaml
+++ b/Unifi-Controller/kubernetes/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers
@@ -16,7 +16,7 @@ spec:
     customRequestHeaders:
       X-Forwarded-Proto: https
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: unifi-controller


### PR DESCRIPTION
The legacy Kubernetes CRDs API group used throughout the repo is deprecated in Traefik v3, which went GA on 29 April 2024.  The legacy references must be updated to the new version.

See: https://doc.traefik.io/traefik/master/migration/v2-to-v3/#kubernetes-crds-api-group-traefikcontainous