### PR TITLE
A few updates for the RKE2 ansible plays

### DIFF
--- a/.devcontainer/rke2/Dockerfile
+++ b/.devcontainer/rke2/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# enable git bash completion
+RUN ln -s /usr/share/bash-completion/completions/git /usr/share/bash-completion/bash_completion
+
+# install sshpass for ansible SSH password auth and vim just in case
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y sshpass vim
+RUN apt-get clean
+
+# install ansible and ansible-lint
+RUN python3 -m pip install ansible-core~=2.16.6 ansible-lint~=24.2.3
+
+# create /workspace directory
+WORKDIR /workspace
+RUN chown -R vscode:vscode /workspace
+
+# run commands as non-root user
+USER vscode
+
+# make prompt multiline cause it's too long by default
+RUN sed -i -E -e '/PS1="\$/c\    PS1="${userpart} ${lightblue}\\w ${gitbranch}${removecolor}\\n\\$ "' ~/.bashrc
+
+# install collection requirements
+COPY collections/requirements.yaml .
+RUN ansible-galaxy collection install -r requirements.yaml

--- a/.devcontainer/rke2/devcontainer.json
+++ b/.devcontainer/rke2/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "ansible-rke2",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../../Ansible/Playbooks/RKE2"
+  },
+  "mounts": ["source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind"],
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bierner.markdown-preview-github-styles",
+        "DavidAnson.vscode-markdownlint",
+        "dhoeric.ansible-vault",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "mhutchie.git-graph",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.isort",
+        "oderwat.indent-rainbow",
+        "redhat.ansible",
+        "samuelcolvin.jinjahtml",
+        "tamasfe.even-better-toml",
+        "yzhang.markdown-all-in-one"
+      ],
+      "settings": {
+        "[json]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[jsonc]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[markdown]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[python]": {
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "ansible.python.interpreterPath": "/usr/local/bin/python",
+        "ansibleVault.executable": "/home/vscode/venv/bin/ansible-vault",
+        "editor.formatOnSave": true,
+        "files.associations": {
+          "*.yaml": "ansible"
+        },
+        "files.trimFinalNewlines": true,
+        "files.trimTrailingWhitespace": true,
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  }
+}

--- a/Ansible/Playbooks/RKE2/ansible.cfg
+++ b/Ansible/Playbooks/RKE2/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = inventory/hosts.ini
+host_key_checking = false

--- a/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
+++ b/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
@@ -9,9 +9,8 @@ metallb_version: v0.13.12
 lb_range: 192.168.3.80-192.168.3.90
 lb_pool_name: first-pool
 
-rke2_version: "v1.29.4+rke2r1"
-rke2_install_dir: "/usr/local/bin"
-rke2_binary_url: "https://github.com/rancher/rke2/releases/download/{{ rke2_version }}/rke2.linux-amd64"
+# Set this if you want a different rke2 version than the default
+# rke2_version: "v1.29.4+rke2r1"
 
 ansible_become: true
 ansible_become_method: sudo

--- a/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
+++ b/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
@@ -13,6 +13,5 @@ rke2_version: "v1.29.4+rke2r1"
 rke2_install_dir: "/usr/local/bin"
 rke2_binary_url: "https://github.com/rancher/rke2/releases/download/{{ rke2_version }}/rke2.linux-amd64"
 
-ansible_user: ubuntu
 ansible_become: true
 ansible_become_method: sudo

--- a/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
+++ b/Ansible/Playbooks/RKE2/inventory/group_vars/all.yaml
@@ -1,16 +1,18 @@
+---
 os: "linux"
 arch: "amd64"
 
-kube_vip_version: "v0.8.0"
-vip_interface: eth0
 vip: 192.168.3.50
 
 metallb_version: v0.13.12
 lb_range: 192.168.3.80-192.168.3.90
 lb_pool_name: first-pool
 
-# Set this if you want a different rke2 version than the default
-# rke2_version: "v1.29.4+rke2r1"
-
 ansible_become: true
 ansible_become_method: sudo
+################################################################################
+# options to change default values
+# kube_vip_version: "v0.8.0"
+# vip_interface: "eth0"
+# rke2_version: "v1.29.4+rke2r1"
+# rke2_install_dir: "/usr/local/bin"

--- a/Ansible/Playbooks/RKE2/inventory/hosts.ini
+++ b/Ansible/Playbooks/RKE2/inventory/hosts.ini
@@ -9,3 +9,12 @@ server3 ansible_host=192.168.3.23
 [agents]
 agent1 ansible_host=192.168.3.24
 agent2 ansible_host=192.168.3.25
+
+[rke2]
+
+[rke2:children]
+servers
+agents
+
+[rke2:vars]
+ansible_user=ansible

--- a/Ansible/Playbooks/RKE2/roles/kube-vip/defaults/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/kube-vip/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+kube_vip_version: v0.8.0
+vip_interface: eth0

--- a/Ansible/Playbooks/RKE2/roles/kube-vip/meta/argument_specs.yml
+++ b/Ansible/Playbooks/RKE2/roles/kube-vip/meta/argument_specs.yml
@@ -1,0 +1,22 @@
+---
+argument_specs:
+  main:
+    short_description: Install kube-vip manifest
+    description: Install kube-vip manifest
+    author:
+      - James Turland <james@turland.uk>
+    options:
+      kube_vip_version:
+        type: str
+        required: false
+        default: v0.8.0
+        description: Version of kube-vip to install
+      vip_interface:
+        type: str
+        required: false
+        default: eth0
+        description: Interface to bind kube-vip
+      vip:
+        type: str
+        required: true
+        description: The virtual IP to use with kube-vip

--- a/Ansible/Playbooks/RKE2/roles/kube-vip/tasks/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/kube-vip/tasks/main.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "/var/lib/rancher/rke2/server/manifests"
     state: directory
-    mode: '0644'
+    mode: "0755"
   when: inventory_hostname in groups['servers']
 
 # Copy kube-vip to server 1 manifest folder for auto deployment at bootstrap
@@ -13,5 +13,5 @@
     dest: /var/lib/rancher/rke2/server/manifests/kube-vip.yaml
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   when: inventory_hostname == groups['servers'][0]

--- a/Ansible/Playbooks/RKE2/roles/rke2-download/defaults/main.yml
+++ b/Ansible/Playbooks/RKE2/roles/rke2-download/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+rke2_install_dir: "/usr/local/bin"
+rke2_version: "v1.29.4+rke2r1"

--- a/Ansible/Playbooks/RKE2/roles/rke2-download/vars/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/rke2-download/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+rke2_binary_url: "https://github.com/rancher/rke2/releases/download/{{ rke2_version }}/rke2.{{ os }}-{{ arch }}"

--- a/Ansible/Playbooks/RKE2/site.yaml
+++ b/Ansible/Playbooks/RKE2/site.yaml
@@ -13,16 +13,11 @@
 
 # bootstraps first server and copies configs for others/agents
 - name: Prepare all nodes
-  hosts: servers,agents
-  gather_facts: true # enables us to gather lots of useful variables: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html
+  hosts: rke2
+  gather_facts: false # fact gathering is slow and not needed for any of our tasks
+  become: true
   roles:
     - prepare-nodes
-
-# creates directories for download and then downloads RKE2 and changes permissions
-- name: Download RKE2
-  hosts: servers,agents
-  gather_facts: true
-  roles:
     - rke2-download
 
 # Creates RKE2 bootstrap manifests folder and copies kube-vip template over (configured with variables)


### PR DESCRIPTION
Not sure if you like squashed commits, but I like small git commits based around a single change, but if you accept the request, I guess you can squash it then.

The first commit adds a devcontainer. I like devcontainers. They're really useful for VS code. It sets up the entire environment you would need to run the plays. It doesn't interfere with anyone who doesn't want to use it. I added it because I needed ansible and didn't want to install anything on my base system.

I added an rke2 group as a supergroup of the servers and agents. Makes for easier easier when you're targeting all groups. Not strictly necessary -- probably more of a personal preference on my part. It could definitely be left out and the targeting kept as is.

The ansible config makes it so you don't have to specify the inventory on the CLI or accept host keys for what are probably test lab servers.

I moved some of the group_vars into role defaults and vars. I could understand wanting all these specified in this "global" vars section so it's easy to know what you can change, but most of the time these things won't be changed, and I think it's more understandable to put the things you NEED to put in there and then go over the "and you could also change these if you wanted". The URL I think is a good change though -- no one will ever need to change that -- it belongs in a vars section in the role.

Fixing directory permissions I think is obvious. You had 644 for a directory. You surely meant 755.

I added an argument specs file for the kube-vip manifest. All the roles would be better with this, but this was as far as I got, and it was the first one with a required value. If someone forgets to put a vip argument in all.yaml, the role will error out. I should have commented out that vip parameter too. It's pretty unlikely someone using this other than you will use that specific IP. I have more thoughts about the vars though. Maybe for another PR.

Finally I combined the first two roles into one play. This feels more natural to me. You're making multiple connections to the same hosts by using two plays which is slower. Maybe you feel it's easier to read or have another reason I've overlooked. Again, this one might be personal preference.

I don't think you should gather facts when they're not used for anything though. It's such a slow task. If you aren't using them, set it to false. Actually, even if you are using them, set it to false, and run the setup module in your role to gather the facts you need. That's more nuanced, but as a rule of thumb.

Love your videos. You do great work.