### PR TITLE
Make host references generic (no more server1), and iterate servers in templates, rather than hardcoding them

### DIFF
--- a/Ansible/Playbooks/RKE2/roles/add-agent/templates/rke2-agent-config.j2
+++ b/Ansible/Playbooks/RKE2/roles/add-agent/templates/rke2-agent-config.j2
@@ -1,5 +1,5 @@
 write-kubeconfig-mode: "0644"
-token: {{ hostvars['server1']['token'] }}
-server: https://{{ hostvars['server1']['ansible_host'] }}:9345
+token: {{ hostvars[groups['servers'][0]]['token'] }}
+server: https://{{ hostvars[groups['servers'][0]]['ansible_host'] }}:9345
 node-label:
   - "agent=true"

--- a/Ansible/Playbooks/RKE2/roles/add-server/templates/rke2-server-config.j2
+++ b/Ansible/Playbooks/RKE2/roles/add-server/templates/rke2-server-config.j2
@@ -1,10 +1,10 @@
 write-kubeconfig-mode: "0644"
-token: {{ hostvars['server1']['token'] }}
-server: https://{{ hostvars['server1']['ansible_host'] }}:9345
+token: {{ hostvars[groups['servers'][0]]['token'] }}
+server: https://{{ hostvars[groups['servers'][0]]['ansible_host'] }}:9345
 tls-san:
   - {{ vip }}
-  - {{ hostvars['server1']['ansible_host'] }}
-  - {{ hostvars['server2']['ansible_host'] }}
-  - {{ hostvars['server3']['ansible_host'] }}
+{% for host in groups['servers'] %}
+  - {{ hostvars[host]['ansible_host'] }}
+{% endfor %}
 node-label:
   - server=true

--- a/Ansible/Playbooks/RKE2/roles/rke2-prepare/tasks/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/rke2-prepare/tasks/main.yaml
@@ -47,7 +47,7 @@
     daemon_reload: true
   when: inventory_hostname in groups['servers'][0]
 
-# wait for node token to be availale so that we can copy it, we need this to join other nodes
+# wait for node token to be available so that we can copy it, we need this to join other nodes
 - name: Wait for node-token
   ansible.builtin.wait_for:
     path: /var/lib/rancher/rke2/server/node-token
@@ -126,9 +126,9 @@
   when: inventory_hostname == groups['servers'][0]
 
 # change IP from local to server 1 IP
-- name: Replace IP address with server1
+- name: Replace IP address with first server
   ansible.builtin.replace:
     path: /home/{{ ansible_user }}/.kube/config
     regexp: '127.0.0.1'
-    replace: "{{ hostvars['server1']['ansible_host'] }}"
+    replace: "{{ hostvars[groups['servers'][0]]['ansible_host'] }}"
   when: inventory_hostname == groups['servers'][0]

--- a/Ansible/Playbooks/RKE2/roles/rke2-prepare/templates/rke2-server-config.j2
+++ b/Ansible/Playbooks/RKE2/roles/rke2-prepare/templates/rke2-server-config.j2
@@ -1,9 +1,9 @@
 write-kubeconfig-mode: "0644"
 tls-san:
   - {{ vip }}
-  - {{ hostvars['server1']['ansible_host'] }}
-  - {{ hostvars['server2']['ansible_host'] }}
-  - {{ hostvars['server3']['ansible_host'] }}
+{% for host in groups['servers'] %}
+  - {{ hostvars[host]['ansible_host'] }}
+{% endfor %}
 node-label:
   - server=true
 disable:


### PR DESCRIPTION
Make all plays accessing "server1" use the first entry in "servers", rather than "server1".

In config templates which list the servers, iterate the members of the "server" group rather than hard-coding the lists.
