### PR TITLE
Fix compose file for Authentik

### DIFF
--- a/Authentik/docker-compose-traefik.yaml
+++ b/Authentik/docker-compose-traefik.yaml
@@ -66,7 +66,7 @@ services:
       - "traefik.http.routers.authentik-secure.rule=Host(`authentik.jimsgarage.co.uk`)"
       - "traefik.http.routers.authentik-secure.tls=true"
       - "traefik.http.routers.authentik-secure.service=authentik"
-      - "traefik.http.services.authentik.loadbalancer.server.scheme=https" 
+      - "traefik.http.services.authentik.loadbalancer.server.scheme=http" 
       - "traefik.http.services.authentik.loadbalancer.server.port=9443"
       - "traefik.docker.network=proxy"
   worker:


### PR DESCRIPTION
Hello Jim, 

```
- "traefik.http.services.authentik.loadbalancer.server.scheme=https" 
```
does not work, we would receive the error 500 Internal Server Error error="tls: first record does not look like a TLS handshake"


I changed from https to http since Authentik responds to http over port 9000.

Thanks!