### PR TITLE
Added hostname to gluetun service in Torrent-VPN docker-compose.yml

### DIFF
--- a/Torrent-VPN/docker-compose.yml
+++ b/Torrent-VPN/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   gluetun:
     image: qmcgaw/gluetun
     container_name: gluetun
+    # Hostname to use for container, required in some instances for the rest of the stack to each other endpoints 
+    hostname: gluetun
     # line above must be uncommented to allow external containers to connect.
     # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/connect-a-container-to-gluetun.md#external-container-to-gluetun
     cap_add:


### PR DESCRIPTION
hostname directive is require in some instances to ensure that the rest of the stack can communicate with each other.