### PR TITLE
Update to v3.0.1-rc4: test-cloudinit.tf

### DIFF
--- a/Terraform/test-cloudinit.tf
+++ b/Terraform/test-cloudinit.tf
@@ -21,11 +21,18 @@ resource "proxmox_vm_qemu" "cloudinit-k3s-master" {
     memory = 4096
     name = "k3s-master-0${count.index + 1}"
 
-    cloudinit_cdrom_storage = "nvme"
+    # cloudinit_cdrom_storage = "nvme" depricated on RC oct-2024
     scsihw   = "virtio-scsi-single" 
     bootdisk = "scsi0"
 
     disks {
+        ide {
+            ide3 {
+                cloudinit {
+                    storage = "nvme"
+                }
+             }
+        }            
         scsi {
             scsi0 {
                 disk {
@@ -69,11 +76,18 @@ resource "proxmox_vm_qemu" "cloudinit-k3s-worker" {
     memory = 4096
     name = "k3s-worker-0${count.index + 1}"
 
-    cloudinit_cdrom_storage = "nvme"
+    # cloudinit_cdrom_storage = "nvme" depricated on RC oct-2024
     scsihw   = "virtio-scsi-single" 
     bootdisk = "scsi0"
 
     disks {
+        ide {
+            ide3 {
+                cloudinit {
+                    storage = "nvme"
+                }
+             }
+        }
         scsi {
             scsi0 {
                 disk {


### PR DESCRIPTION
The `cloudinit_cdrom_storage = "nvme"` option is obsolete in the latest Telmate Proxmox module, as it has been updated to the latest RC4 specifications. The script is now functioning again, but the latest version from master still needs to be *compiled* and manual installed as shown in the video!! Currently, working with version v3.0.1-rc4.