### PR TITLE
Kubernetes - Update traefik redirectTo => redirections

### DIFF
--- a/Kubernetes/Traefik-PiHole/Helm/Traefik/values.yaml
+++ b/Kubernetes/Traefik-PiHole/Helm/Traefik/values.yaml
@@ -19,9 +19,11 @@ nodeSelector:
 
 ports:
   web:
-    redirectTo:
-      port: websecure
+    redirections:
+      to: websecure
       priority: 10
+      schema: https
+      permanent: true
   websecure:
     tls:
       enabled: true


### PR DESCRIPTION
In the newest [release of the treafik helm chart ](https://github.com/traefik/traefik-helm-chart/releases/tag/v34.0.0) they introduced some breaking changes. The port redirections from the web to the websecure port was previously done with a different syntax. 

A good example can be found in this PR: https://github.com/traefik/traefik-helm-chart/pull/1301