### PR TITLE
Pinned k3s Version

### DIFF
--- a/Kubernetes/Longhorn/longhorn-K3S.sh
+++ b/Kubernetes/Longhorn/longhorn-K3S.sh
@@ -42,6 +42,9 @@ storage=($longhorn1 $longhorn2 $longhorn3)
 #ssh certificate name variable
 certName=id_rsa
 
+# K3S Version
+k3sVersion="v1.26.10+k3s2"
+
 #############################################
 #            DO NOT EDIT BELOW              #
 #############################################
@@ -69,7 +72,7 @@ for newnode in "${storage[@]}"; do
     --ip $newnode \
     --user $user \
     --sudo \
-    --k3s-channel stable \
+    --k3s-version $k3sVersion \
     --server-ip $master1 \
     --k3s-extra-args "--node-label \"longhorn=true\"" \
     --ssh-key $HOME/.ssh/$certName


### PR DESCRIPTION
Following the YouTube series i encountered a fatal problem with the new release of k3s being 1.27.x whilst having the k3s version v1.26.10+k3s2 for my other nodes from your prior script.

The script for installing k3s is working with a pinned version (v1.26.10+k3s2). As a good measure i would either put them both on the stable channel or leave both of them at the same fixed version. 

Thanks for your work Jim and the great explanation!