### PR TITLE
docs: fix importdisk command

### DIFF
--- a/Kubernetes/Cloud-Init/readme.md
+++ b/Kubernetes/Cloud-Init/readme.md
@@ -4,7 +4,7 @@
 qm create 5000 --memory 2048 --core 2 --name ubuntu-cloud --net0 virtio,bridge=vmbr0
 cd /var/lib/vz/template/iso/
 qm importdisk 5000 lunar-server-cloudimg-amd64-disk-kvm.img <YOUR STORAGE HERE>
-qm set 5000 --scsihw virtio-scsi-pci --scsi0 <YOUR STORAGE HERE>:5000/vm-5000-disk-0.raw
+qm set 5000 --scsihw virtio-scsi-pci --scsi0 <YOUR STORAGE HERE>/vm-5000-disk-0
 qm set 5000 --ide2 <YOUR STORAGE HERE>:cloudinit
 qm set 5000 --boot c --bootdisk scsi0
 qm set 5000 --serial0 socket --vga serial0

--- a/Kubernetes/Cloud-Init/readme.md
+++ b/Kubernetes/Cloud-Init/readme.md
@@ -4,7 +4,7 @@
 qm create 5000 --memory 2048 --core 2 --name ubuntu-cloud --net0 virtio,bridge=vmbr0
 cd /var/lib/vz/template/iso/
 qm importdisk 5000 lunar-server-cloudimg-amd64-disk-kvm.img <YOUR STORAGE HERE>
-qm set 5000 --scsihw virtio-scsi-pci --scsi0 <YOUR STORAGE HERE>/vm-5000-disk-0
+qm set 5000 --scsihw virtio-scsi-pci --scsi0 <YOUR STORAGE HERE>:vm-5000-disk-0
 qm set 5000 --ide2 <YOUR STORAGE HERE>:cloudinit
 qm set 5000 --boot c --bootdisk scsi0
 qm set 5000 --serial0 socket --vga serial0


### PR DESCRIPTION
The importdisk command when creating the VM template is incorrect.
It should not include the VM's ID after storage nor have `.raw` extension.

```
> qm set 5000 --scsihw virtio-scsi-pci --scsi0 mystorage:5000/vm-5000-disk-0.raw
unable to parse zfs volume name '5000/vm-5000-disk-0.raw'
```

```
> qm set 5000 --scsihw virtio-scsi-pci --scsi0 mystorage:vm-5000-disk-0
update VM 5000: -scsi0 ssdpool:vm-5000-disk-0 -scsihw virtio-scsi-pci
```