### PR TITLE
Fix RKE2 MetalLB L2Advertisement to honor custom lb_pool_name (#135)

### DIFF
--- a/Ansible/Playbooks/RKE2/roles/apply-manifests/tasks/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/apply-manifests/tasks/main.yaml
@@ -33,10 +33,20 @@
   become_user: "{{ ansible_user }}"
   when: inventory_hostname == groups['servers'][0]
 
+# Deploy L2 Advertisement to Server 1 (templated so it matches lb_pool_name)
+- name: Copy metallb L2 Advertisement to server 1
+  ansible.builtin.template:
+    src: templates/metallb-l2advertisement.j2
+    dest: /home/{{ ansible_user }}/l2advertisement.yaml
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
+  when: inventory_hostname == groups['servers'][0]
+
 # Apply L2 Advertisement for metallb
 - name: Apply metallb L2 Advertisement
   ansible.builtin.command:
-    cmd: kubectl apply -f https://raw.githubusercontent.com/JamesTurland/JimsGarage/main/Kubernetes/RKE2/l2Advertisement.yaml
+    cmd: kubectl apply -f /home/{{ ansible_user }}/l2advertisement.yaml
   become_user: "{{ ansible_user }}"
   changed_when: true
   when: inventory_hostname == groups['servers'][0]

--- a/Ansible/Playbooks/RKE2/roles/apply-manifests/tasks/main.yaml
+++ b/Ansible/Playbooks/RKE2/roles/apply-manifests/tasks/main.yaml
@@ -6,6 +6,7 @@
   retries: 120
   delay: 10
   changed_when: true
+  become: true
   become_user: "{{ ansible_user }}"
   when: inventory_hostname == groups['servers'][0]
 
@@ -13,6 +14,7 @@
 - name: Apply metallb namespace
   ansible.builtin.command:
     cmd: kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+  become: true
   become_user: "{{ ansible_user }}"
   changed_when: true
   when: inventory_hostname == groups['servers'][0]
@@ -21,6 +23,7 @@
 - name: Apply metallb manifest
   ansible.builtin.command:
     cmd: kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/{{ metallb_version }}/config/manifests/metallb-native.yaml
+  become: true
   become_user: "{{ ansible_user }}"
   changed_when: true
   when: inventory_hostname == groups['servers'][0]
@@ -30,6 +33,7 @@
   ansible.builtin.command:
     cmd: "kubectl wait --namespace metallb-system --for=condition=ready pod --selector=component=controller --timeout=1800s"
   changed_when: true
+  become: true
   become_user: "{{ ansible_user }}"
   when: inventory_hostname == groups['servers'][0]
 
@@ -47,6 +51,7 @@
 - name: Apply metallb L2 Advertisement
   ansible.builtin.command:
     cmd: kubectl apply -f /home/{{ ansible_user }}/l2advertisement.yaml
+  become: true
   become_user: "{{ ansible_user }}"
   changed_when: true
   when: inventory_hostname == groups['servers'][0]
@@ -65,6 +70,7 @@
 - name: Apply metallb ipppool
   ansible.builtin.command:
     cmd: kubectl apply -f /home/{{ ansible_user }}/ippool.yaml
+  become: true
   become_user: "{{ ansible_user }}"
   changed_when: true
   when: inventory_hostname == groups['servers'][0]

--- a/Ansible/Playbooks/RKE2/roles/apply-manifests/templates/metallb-l2advertisement.j2
+++ b/Ansible/Playbooks/RKE2/roles/apply-manifests/templates/metallb-l2advertisement.j2
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - {{ lb_pool_name }}


### PR DESCRIPTION
## What & why

Fixes #135.

In `Ansible/Playbooks/RKE2/roles/apply-manifests`, the **IPAddressPool** is
rendered from a template using the configurable `lb_pool_name` variable, but the
**L2Advertisement** was applied straight from a hardcoded remote file
(`Kubernetes/RKE2/l2Advertisement.yaml`) where the pool name is baked in as
`first-pool`.

Set `lb_pool_name` to anything other than `first-pool` and the L2Advertisement
ends up referencing a pool that does not exist. MetalLB's controller still
assigns LoadBalancer IPs from the pool, but the speaker never advertises them —
services get an external IP yet are unreachable on the network.

## Changes

### Bugfix (#135) — commit 1

- Add `templates/metallb-l2advertisement.j2`, which uses `{{ lb_pool_name }}`.
- Render + apply it locally, mirroring the existing IPAddressPool pattern,
  instead of `kubectl apply -f`-ing the hardcoded remote file. The IPPool and the
  L2Advertisement now always reference the same pool name.

The new copy task deliberately has no `become_user` and sets `owner`/`group`
explicitly — identical to the existing "Copy metallb IPPool" task. The old
`Kubernetes/RKE2/l2Advertisement.yaml` is left in place as it may be referenced
elsewhere / by the video walkthrough.

### Lint fix — commit 2

Resolves ansible-lint's `partial-become` findings in this role (6 tasks):

- Add an explicit `become: true` alongside the existing `become_user` on the
  `kubectl` command tasks.
- `become` is already enabled globally via `ansible_become` in
  `group_vars/all.yaml`, so this is **behavior-neutral** — verified with
  `ansible-playbook -vvv` that the escalation target stays `ansible` (which owns
  `~/.kube/config`), not root. It simply makes the intent explicit in each task,
  which is what the rule (tag: `unpredictability`) is asking for, and drives the
  role's `partial-become` count to zero.
- The remaining `role-name` finding (hyphenated role dirs) is repo-wide — every
  role is affected — so it's left for a separate coordinated rename +
  `site.yaml` update rather than bundled here.

## Test plan

Tested with `ansible-core 2.20.1` / `ansible-lint 26.1.1`, and a live
`k3d` + MetalLB `v0.13.12` cluster (the version pinned in `group_vars/all.yaml`).

### 1. Syntax check and lint (no regressions)

```
$ ansible-playbook --syntax-check site.yaml
playbook: site.yaml            # exit 0
```

Lint compared against `main` for the touched role. The six `partial-become`
findings are resolved by the second commit (explicit `become: true`), and no new
findings are introduced:

```
# main (baseline): role-name + 6x partial-become
# this branch:     role-name only
$ ansible-lint -f pep8 roles/apply-manifests/
roles/apply-manifests:1: role-name: Role name apply-manifests does not match pattern
```

The lone remaining `role-name` finding is repo-wide (every role dir is
hyphenated) and out of scope for this PR — it needs a coordinated rename +
`site.yaml` update.

### 2. Faithful template render with a NON-default pool name

Rendered both templates through Ansible's templar with `lb_pool_name: main-pool`
and asserted the L2Advertisement references the pool:

```
TASK [Show rendered manifests] ...
    "IPAddressPool.metadata.name = main-pool"
    "L2Advertisement.spec.ipAddressPools = ['main-pool']"
TASK [Assert the L2Advertisement references the IPAddressPool by name] ...
ok: [localhost] => "PASS: L2Advertisement references pool 'main-pool' (names match)"
```

### 3. Live k3d + MetalLB reproduction (before/after)

One node, `servicelb` disabled so MetalLB owns LoadBalancer; pool range taken
from the k3d docker subnet (`172.20.0.0/16`); `lb_pool_name: main-pool`; a
`type: LoadBalancer` test service.

Setup:

```
# Throwaway kubeconfig so the real one is never touched
export KUBECONFIG="$(mktemp -d)/kubeconfig"

# Disable servicelb so MetalLB owns LoadBalancer (traefik off for noise)
k3d cluster create metallb-test \
  --k3s-arg "--disable=servicelb@server:*" \
  --k3s-arg "--disable=traefik@server:*" \
  --wait --timeout 180s
k3d kubeconfig get metallb-test > "$KUBECONFIG"

# Pool range must live inside the k3d docker subnet
docker network inspect k3d-metallb-test \
  -f '{{range .IPAM.Config}}{{.Subnet}} gw={{.Gateway}}{{end}}'   # 172.20.0.0/16

# MetalLB v0.13.12 (matches group_vars/all.yaml)
kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
kubectl wait -n metallb-system --for=condition=available deploy/controller --timeout=180s
kubectl wait -n metallb-system --for=condition=ready pod -l component=speaker --timeout=120s

# ... then apply the IPAddressPool (main-pool), an L2Advertisement, and a
#     type: LoadBalancer test service. Teardown: k3d cluster delete metallb-test
```

**Before (old hardcoded `first-pool` advertisement, mismatched):** IP assigned
but never announced.

```
$ kubectl -n lb-test get svc echo-lb -o wide
NAME      TYPE           EXTERNAL-IP      PORT(S)
echo-lb   LoadBalancer   172.20.255.200   80:32716/TCP

$ kubectl -n lb-test describe svc echo-lb   # Events
  Normal  IPAllocated  metallb-controller  Assigned IP ["172.20.255.200"]
  # <-- no announcement event

$ docker run --rm --network k3d-metallb-test curlimages/curl -s --max-time 6 http://172.20.255.200/hostname
  # exit 7 (no route — never advertised)
```

**After (templated `main-pool` advertisement, matched):** speaker announces, IP
reachable.

```
$ kubectl -n lb-test describe svc echo-lb   # Events
  Normal  IPAllocated   metallb-controller  Assigned IP ["172.20.255.200"]
  Normal  nodeAssigned  metallb-speaker     announcing from node "k3d-metallb-test-server-0" with protocol "layer2"

$ docker run --rm --network k3d-metallb-test curlimages/curl -s --max-time 6 http://172.20.255.200/hostname
echo-bff8c9f65-shzmd            # exit 0 (reachable)
```

Toggling the advertisement between `first-pool` and `main-pool` flips
reachability deterministically.
