### PR TITLE
Komodo Fix in image link + set fixed version

### DIFF
--- a/Komodo/.env
+++ b/Komodo/.env
@@ -8,7 +8,7 @@
 ## so you can pass any additional environment variables to Core / Periphery directly in this file as well.
 
 ## Follows "major.minor.patch" semver.
-COMPOSE_KOMODO_IMAGE_TAG="2"
+COMPOSE_KOMODO_IMAGE_TAG="2.2.0"
 ## Store dated database backups on the host - https://komo.do/docs/setup/backup
 COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups
 

--- a/Komodo/.env
+++ b/Komodo/.env
@@ -1,5 +1,5 @@
 ####################################
-# ðŸ¦Ž KOMODO COMPOSE - VARIABLES ðŸ¦Ž #
+# 🦎 KOMODO COMPOSE - VARIABLES 🦎 #
 ####################################
 
 ## These compose variables can be used with all Komodo deployment options.
@@ -7,60 +7,73 @@
 ## Additionally, they are passed to both Komodo Core and Komodo Periphery with `env_file: ./compose.env`,
 ## so you can pass any additional environment variables to Core / Periphery directly in this file as well.
 
-## Stick to a specific version, or use `latest`
-COMPOSE_KOMODO_IMAGE_TAG=latest
+## Follows "major.minor.patch" semver.
+COMPOSE_KOMODO_IMAGE_TAG="2"
+## Store dated database backups on the host - https://komo.do/docs/setup/backup
+COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups
 
-## Note: ðŸš¨ Podman does NOT support local logging driver ðŸš¨. See Podman options here:
-## `https://docs.podman.io/en/v4.6.1/markdown/podman-run.1.html#log-driver-driver`
-COMPOSE_LOGGING_DRIVER=local # Enable log rotation with the local driver.
+## DB credentials
+KOMODO_DATABASE_USERNAME=admin
+KOMODO_DATABASE_PASSWORD=admin
 
-## DB credentials - Ignored for Sqlite
-DB_USERNAME=admin
-DB_PASSWORD=admin
-
-## Configure a secure passkey to authenticate between Core / Periphery.
-PASSKEY=a_random_passkey
+## Set your time zone for schedules
+## https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TZ=Etc/UTC
 
 #=-------------------------=#
 #= Komodo Core Environment =#
 #=-------------------------=#
 
 ## Full variable list + descriptions are available here:
-## ðŸ¦Ž https://github.com/mbecker20/komodo/blob/main/config/core.config.toml ðŸ¦Ž
+## 🦎 https://github.com/moghtech/komodo/blob/main/config/core.config.toml 🦎
 
 ## Note. Secret variables also support `${VARIABLE}_FILE` syntax to pass docker compose secrets.
 ## Docs: https://docs.docker.com/compose/how-tos/use-secrets/#examples
 
-## Used for Oauth / Webhook url suggestion / Caddy reverse proxy.
-KOMODO_HOST=https://demo.komo.do
+## Used for Oauth / Webhook url suggestion.
+KOMODO_HOST=https://example.komodo.com
 ## Displayed in the browser tab.
 KOMODO_TITLE=Komodo
-## Create a server matching this address as the "first server".
-## Use `https://host.docker.internal:8120` when using systemd-managed Periphery.
-KOMODO_FIRST_SERVER=https://periphery:8120
-## Make all buttons just double-click, rather than the full confirmation dialog.
+
+## Allow Periphery to connect via generated public key
+KOMODO_PERIPHERY_PUBLIC_KEY=file:/config/keys/periphery.pub
+
+## Enable login with username + password.
+KOMODO_LOCAL_AUTH=true
+## Set the initial admin username created upon first launch.
+## Comment out to disable initial user creation,
+## and create first user using signup button.
+KOMODO_INIT_ADMIN_USERNAME=admin
+KOMODO_INIT_ADMIN_PASSWORD=changeme
+
+## Create a first Server with a custom name.
+## Usually the system hostname is good.
+KOMODO_FIRST_SERVER_NAME=Local
+
+## Make execute buttons just double-click, rather than the full confirmation dialog.
 KOMODO_DISABLE_CONFIRM_DIALOG=false
 
-## Rate Komodo polls your servers for
-## status / container status / system stats / alerting.
-## Options: 1-sec, 5-sec, 15-sec, 1-min, 5-min.
-## Default: 15-sec
-KOMODO_MONITORING_INTERVAL="15-sec"
-## Rate Komodo polls Resources for updates,
-## like outdated commit hash.
-## Options: 1-min, 5-min, 15-min, 30-min, 1-hr.
-## Default: 5-min
-KOMODO_RESOURCE_POLL_INTERVAL="5-min"
+## Disable creating the default Procedures on first startup.
+KOMODO_DISABLE_INIT_RESOURCES=false
 
-## Used to auth against periphery. Alt: KOMODO_PASSKEY_FILE
-KOMODO_PASSKEY=${PASSKEY}
 ## Used to auth incoming webhooks. Alt: KOMODO_WEBHOOK_SECRET_FILE
 KOMODO_WEBHOOK_SECRET=a_random_secret
 ## Used to generate jwt. Alt: KOMODO_JWT_SECRET_FILE
 KOMODO_JWT_SECRET=a_random_jwt_secret
+## Time to live for jwt tokens.
+## Options: 1-hr, 12-hr, 1-day, 3-day, 1-wk, 2-wk
+KOMODO_JWT_TTL="1-day"
 
-## Enable login with username + password.
-KOMODO_LOCAL_AUTH=true
+## Rate Komodo polls your servers for
+## status / container status / system stats / alerting.
+## Options: 1-sec, 5-sec, 15-sec, 1-min, 5-min, 15-min
+## Default: 15-sec
+KOMODO_MONITORING_INTERVAL="15-sec"
+## Interval at which to poll Resources for any updates / automated actions.
+## Options: 5-min, 15-min, 1-hr, 2-hr, 6-hr, 12-hr, 1-day
+## Default: 1-hr
+KOMODO_RESOURCE_POLL_INTERVAL="1-hr"
+
 ## Disable new user signups.
 KOMODO_DISABLE_USER_REGISTRATION=false
 ## All new logins are auto enabled
@@ -70,10 +83,6 @@ KOMODO_DISABLE_NON_ADMIN_CREATE=false
 ## Allows all users to have Read level access to all resources.
 KOMODO_TRANSPARENT_MODE=false
 
-## Time to live for jwt tokens.
-## Options: 1-hr, 12-hr, 1-day, 3-day, 1-wk, 2-wk
-KOMODO_JWT_TTL="1-day"
-
 ## OIDC Login
 KOMODO_OIDC_ENABLED=false
 ## Must reachable from Komodo Core container
@@ -81,10 +90,13 @@ KOMODO_OIDC_ENABLED=false
 ## Change the host to one reachable be reachable by users (optional if it is the same as above).
 ## DO NOT include the `path` part of the URL.
 # KOMODO_OIDC_REDIRECT_HOST=https://oidc.provider.external
-## Your client credentials
+## Your OIDC client id
 # KOMODO_OIDC_CLIENT_ID= # Alt: KOMODO_OIDC_CLIENT_ID_FILE
+## Your OIDC client secret.
+## If your provider supports PKCE flow, this can be ommitted.
 # KOMODO_OIDC_CLIENT_SECRET= # Alt: KOMODO_OIDC_CLIENT_SECRET_FILE
 ## Make usernames the full email.
+## Note. This does not work for all OIDC providers.
 # KOMODO_OIDC_USE_FULL_EMAIL=true
 ## Add additional trusted audiences for token claims verification.
 ## Supports comma separated list, and passing with _FILE (for compose secrets).
@@ -100,31 +112,56 @@ KOMODO_GOOGLE_OAUTH_ENABLED=false
 # KOMODO_GOOGLE_OAUTH_ID= # Alt: KOMODO_GOOGLE_OAUTH_ID_FILE
 # KOMODO_GOOGLE_OAUTH_SECRET= # Alt: KOMODO_GOOGLE_OAUTH_SECRET_FILE
 
-## Aws - Used to launch Builder instances and ServerTemplate instances.
+## Aws - Used to launch Builder instances.
 KOMODO_AWS_ACCESS_KEY_ID= # Alt: KOMODO_AWS_ACCESS_KEY_ID_FILE
 KOMODO_AWS_SECRET_ACCESS_KEY= # Alt: KOMODO_AWS_SECRET_ACCESS_KEY_FILE
 
-## Hetzner - Used to launch ServerTemplate instances
-## Hetzner Builder not supported due to Hetzner pay-by-the-hour pricing model
-KOMODO_HETZNER_TOKEN= # Alt: KOMODO_HETZNER_TOKEN_FILE
+## Prettier logging with empty lines between logs
+KOMODO_LOGGING_PRETTY=false
+## More human readable logging of startup config (multi-line)
+KOMODO_PRETTY_STARTUP_CONFIG=false
 
 #=------------------------------=#
 #= Komodo Periphery Environment =#
 #=------------------------------=#
 
 ## Full variable list + descriptions are available here:
-## ðŸ¦Ž https://github.com/mbecker20/komodo/blob/main/config/periphery.config.toml ðŸ¦Ž
+## 🦎 https://github.com/moghtech/komodo/blob/main/config/periphery.config.toml 🦎
 
-## Periphery passkeys must include KOMODO_PASSKEY to authenticate
-PERIPHERY_PASSKEYS=${PASSKEY}
+## Point Periphery to Core for connection
+PERIPHERY_CORE_ADDRESS=ws://core:9120
+## Use the same name as KOMODO_FIRST_SERVER_NAME to connect
+PERIPHERY_CONNECT_AS=${KOMODO_FIRST_SERVER_NAME}
+## Use the public key generated by Core.
+PERIPHERY_CORE_PUBLIC_KEYS=file:/config/keys/core.pub
 
-## Enable SSL using self signed certificates.
-## Connect to Periphery at https://address:8120.
-PERIPHERY_SSL_ENABLED=true
+## Specify the root directory used by Periphery agent.
+## All your compose files and repos need to be inside this directory
+## for Periphery to interact with them.
+## - ROOT_DIRECTORY (/etc/komodo)
+## --- ./stacks
+## ------ ./my_stack_1
+## ------ ./my_stack_2
+## --- ./repos
+## ------ ./my_repo_1
+## --- ./builds
+PERIPHERY_ROOT_DIRECTORY=/etc/komodo
 
-## If the disk size is overreporting, can use one of these to 
+## Specify whether to disable the terminals feature
+## and disallow remote shell access (inside the Periphery container).
+PERIPHERY_DISABLE_TERMINALS=false
+## Specify whether to disable the container exec / attach features
+## and disallow remote container shell access.
+PERIPHERY_DISABLE_CONTAINER_TERMINALS=false
+
+## If the disk size is overreporting, can use one of these to
 ## whitelist / blacklist the disks to filter them, whichever is easier.
 ## Accepts comma separated list of paths.
 ## Usually whitelisting just /etc/hostname gives correct size.
 PERIPHERY_INCLUDE_DISK_MOUNTS=/etc/hostname
 # PERIPHERY_EXCLUDE_DISK_MOUNTS=/snap,/etc/repos
+
+## Prettier logging with empty lines between logs
+PERIPHERY_LOGGING_PRETTY=false
+## More human readable logging of startup config (multi-line)
+PERIPHERY_PRETTY_STARTUP_CONFIG=false

--- a/Komodo/docker-compose.yaml
+++ b/Komodo/docker-compose.yaml
@@ -76,5 +76,7 @@ volumes:
   # Mongo
   mongo-data:
   mongo-config:
+  # Core
+  repo-cache:
   # Core / Periphery
   keys:

--- a/Komodo/docker-compose.yaml
+++ b/Komodo/docker-compose.yaml
@@ -26,9 +26,9 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${DB_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
-  
+
   core:
-    image: ghcr.io/mbecker20/komodo:${COMPOSE_KOMODO_IMAGE_TAG:-latest}
+    image: ghcr.io/moghtech/komodo-core:2.2.0
     labels:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     restart: unless-stopped
@@ -52,16 +52,16 @@ services:
       # - /path/to/syncs:/syncs
       ## Optionally mount a custom core.config.toml
       # - /path/to/core.config.toml:/config/config.toml
-    ## Allows for systemd Periphery connection at 
+    ## Allows for systemd Periphery connection at
     ## "http://host.docker.internal:8120"
     # extra_hosts:
     #   - host.docker.internal:host-gateway
 
   ## Deploy Periphery container using this block,
-  ## or deploy the Periphery binary with systemd using 
+  ## or deploy the Periphery binary with systemd using
   ## https://github.com/mbecker20/komodo/tree/main/scripts
   periphery:
-    image: ghcr.io/mbecker20/periphery:${COMPOSE_KOMODO_IMAGE_TAG:-latest}
+    image: ghcr.io/moghtech/komodo-periphery:2.2.0
     labels:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     restart: unless-stopped
@@ -75,13 +75,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       ## Allow Periphery to see processes outside of container
       - /proc:/proc
-      ## use self signed certs in docker volume, 
+      ## use self signed certs in docker volume,
       ## or mount your own signed certs.
       - ssl-certs:/etc/komodo/ssl
-      ## manage repos in a docker volume, 
+      ## manage repos in a docker volume,
       ## or change it to an accessible host directory.
       - repos:/etc/komodo/repos
-      ## manage stack files in a docker volume, 
+      ## manage stack files in a docker volume,
       ## or change it to an accessible host directory.
       - stacks:/etc/komodo/stacks
       ## Optionally mount a path to store compose files

--- a/Komodo/docker-compose.yaml
+++ b/Komodo/docker-compose.yaml
@@ -1,5 +1,5 @@
 ################################
-# ðŸ¦Ž KOMODO COMPOSE - MONGO ðŸ¦Ž #
+# 🦎 KOMODO COMPOSE - MONGO 🦎 #
 ################################
 
 ## This compose file will deploy:
@@ -14,89 +14,67 @@ services:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     command: --quiet --wiredTigerCacheSizeGB 0.25
     restart: unless-stopped
-    logging:
-      driver: ${COMPOSE_LOGGING_DRIVER:-local}
-    networks:
-      - default
     # ports:
     #   - 27017:27017
     volumes:
       - mongo-data:/data/db
       - mongo-config:/data/configdb
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${DB_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
+      MONGO_INITDB_ROOT_USERNAME: ${KOMODO_DATABASE_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${KOMODO_DATABASE_PASSWORD}
 
   core:
-    image: ghcr.io/moghtech/komodo-core:2.2.0
-    labels:
-      komodo.skip: # Prevent Komodo from stopping with StopAllContainers
+    image: ghcr.io/moghtech/komodo-core:${COMPOSE_KOMODO_IMAGE_TAG:-2}
+    init: true
     restart: unless-stopped
     depends_on:
       - mongo
-    logging:
-      driver: ${COMPOSE_LOGGING_DRIVER:-local}
-    networks:
-      - default
     ports:
       - 9120:9120
     env_file: .env
     environment:
       KOMODO_DATABASE_ADDRESS: mongo:27017
-      KOMODO_DATABASE_USERNAME: ${DB_USERNAME}
-      KOMODO_DATABASE_PASSWORD: ${DB_PASSWORD}
     volumes:
       ## Core cache for repos for latest commit hash / contents
       - repo-cache:/repo-cache
+      ## Attach the Core / Periphery communication keys
+      - keys:/config/keys
+      ## Store dated backups of the database - https://komo.do/docs/setup/backup
+      - ${COMPOSE_KOMODO_BACKUPS_PATH}:/backups
       ## Store sync files on server
       # - /path/to/syncs:/syncs
       ## Optionally mount a custom core.config.toml
       # - /path/to/core.config.toml:/config/config.toml
-    ## Allows for systemd Periphery connection at
-    ## "http://host.docker.internal:8120"
-    # extra_hosts:
-    #   - host.docker.internal:host-gateway
 
   ## Deploy Periphery container using this block,
   ## or deploy the Periphery binary with systemd using
-  ## https://github.com/mbecker20/komodo/tree/main/scripts
+  ## https://github.com/moghtech/komodo/tree/main/scripts
   periphery:
-    image: ghcr.io/moghtech/komodo-periphery:2.2.0
-    labels:
-      komodo.skip: # Prevent Komodo from stopping with StopAllContainers
+    image: ghcr.io/moghtech/komodo-periphery:${COMPOSE_KOMODO_IMAGE_TAG:-2}
+    init: true
     restart: unless-stopped
-    logging:
-      driver: ${COMPOSE_LOGGING_DRIVER:-local}
-    networks:
-      - default
+    depends_on:
+      - core
     env_file: .env
     volumes:
+      ## Attach the Core / Periphery communication keys
+      - keys:/config/keys
       ## Mount external docker socket
       - /var/run/docker.sock:/var/run/docker.sock
       ## Allow Periphery to see processes outside of container
       - /proc:/proc
-      ## use self signed certs in docker volume,
-      ## or mount your own signed certs.
-      - ssl-certs:/etc/komodo/ssl
-      ## manage repos in a docker volume,
-      ## or change it to an accessible host directory.
-      - repos:/etc/komodo/repos
-      ## manage stack files in a docker volume,
-      ## or change it to an accessible host directory.
-      - stacks:/etc/komodo/stacks
-      ## Optionally mount a path to store compose files
-      # - /path/to/compose:/host/compose
+      ## Specify the Periphery agent root directory.
+      ## All your configs / repos must be children of this directory for Periphery to be able to see it.
+      ## Must be the same inside and outside the container,
+      ## or docker will get confused. See https://github.com/moghtech/komodo/discussions/180.
+      ## Default: /etc/komodo.
+      - ${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}:${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}
+      ## Optionally mount a custom periphery.config.toml
+      # - /path/to/periphery.config.toml:/config/config.toml
 
 volumes:
   # Mongo
   mongo-data:
   mongo-config:
-  # Core
-  repo-cache:
-  # Periphery
-  ssl-certs:
-  repos:
-  stacks:
-
-networks:
-  default: {}
+  # Core / Periphery
+  keys:


### PR DESCRIPTION
## What
Fixes the container image references in `Komodo/docker-compose.yaml` and pins them to a fixed release instead of `latest`.

## Why
The `core` and `periphery` services pointed at outdated/incorrect image paths under the old `mbecker20` namespace, which no longer resolve. Komodo's official images now live under the `moghtech` namespace as `komodo-core` and `komodo-periphery`. Using the `:latest` tag also makes deployments non-reproducible and prone to breaking on upstream changes.

## Changes
- `core`: `ghcr.io/mbecker20/komodo:${COMPOSE_KOMODO_IMAGE_TAG:-latest}` → `ghcr.io/moghtech/komodo-core:2.2.0`
- `periphery`: `ghcr.io/mbecker20/periphery:${COMPOSE_KOMODO_IMAGE_TAG:-latest}` → `ghcr.io/moghtech/komodo-periphery:2.2.0`

## Verification
- Confirmed the image names against Komodo's official upstream compose file (`moghtech/komodo`), which uses `ghcr.io/moghtech/komodo-core` and `ghcr.io/moghtech/komodo-periphery`.
