### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Here's a collection of Docker Compose and config files for use in my videos. Sim
 
 ## Star History
 
-<a href="https://star-history.com/#JamesTurland/JimsGarage&Date">
+<a href="https://star-history.dera.page/#JamesTurland/JimsGarage&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=JamesTurland/JimsGarage&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=JamesTurland/JimsGarage&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JamesTurland/JimsGarage&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=JamesTurland/JimsGarage&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=JamesTurland/JimsGarage&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=JamesTurland/JimsGarage&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History chart in the README stopped rendering due to GitHub stargazer API restrictions. This PR moves the chart to star-history.dera.page, an alternative that uses a different data source and requires no API token, so the chart works again.